### PR TITLE
fix: 修正可编辑标签query

### DIFF
--- a/src/feature/mp.ts
+++ b/src/feature/mp.ts
@@ -2,7 +2,7 @@
  * @Author: h-yw 1327603193@qq.com
  * @Date: 2024-09-08 03:07:04
  * @LastEditors: Please set LastEditors
- * @LastEditTime: 2024-09-12 17:41:57
+ * @LastEditTime: 2024-12-01 13:35:51
  * @Description: 注入浏览器的方法，资源与插件内不共用，再次定义了MessageType枚举和appmsg
  */
 
@@ -29,10 +29,11 @@ export enum EMode {
   Edit = "edit",
 }
 
-const iframe = document.querySelector("iframe") as HTMLIFrameElement;
+const iframe = document.querySelector(".ProseMirror") as HTMLDivElement;
 
 const rich = getRichMedia();
 chrome.runtime.onMessage.addListener(({ type, data }) => {
+  console.log("mp contentscript", type, data);
   if (type === MessageType.SendMPEditorValue) {
     console.log("save======", data);
     rich.innerHTML = data.data;
@@ -62,6 +63,6 @@ chrome.runtime.onMessage.addListener(({ type, data }) => {
 });
 
 function getRichMedia() {
-  const rich = iframe?.contentDocument?.body as HTMLBodyElement;
+  const rich = iframe;
   return rich;
 }


### PR DESCRIPTION
微信修改了可编辑div的位置，之前是嵌套这在iframe中，现在取消了iframe。这造成content-script无法查找到可编辑标签。